### PR TITLE
Rework obb calculations

### DIFF
--- a/tools/ytyphelper.py
+++ b/tools/ytyphelper.py
@@ -39,7 +39,7 @@ def base_archetype_from_object(obj):
 def ytyp_from_objects(objs):
     ytyp = CMapTypes()
     ytyp.name = os.path.basename(
-        bpy.data.filepath).replace(".blend", "") if bpy.data.filepath is not "" else "untitled"
+        bpy.data.filepath).replace(".blend", "") if bpy.data.filepath != "" else "untitled"
     for obj in objs:
         ytyp.archetypes.append(base_archetype_from_object(obj))
     return ytyp

--- a/ybn/ui.py
+++ b/ybn/ui.py
@@ -271,8 +271,10 @@ class SOLLUMZ_PT_CREATE_BOUND_PANEL(CollisionToolChildPanel, bpy.types.Panel):
         subrow = split.row(align=True)
         subrow.prop(context.scene, "poly_bound_type_verts", text="")
         subrow.prop(context.window_manager, "sz_create_bound_box_parent", text="", placeholder="Parent")
+
         box_parent = context.window_manager.sz_create_bound_box_parent
         box_from_verts_op.parent_name = box_parent.name if box_parent else ""
+        box_from_verts_op.sollum_type = context.scene.poly_bound_type_verts
 
 
 class SOLLUMZ_PT_CREATE_MATERIAL_PANEL(CollisionToolChildPanel, bpy.types.Panel):

--- a/ytyp/properties/mlo.py
+++ b/ytyp/properties/mlo.py
@@ -161,12 +161,18 @@ class PortalProperties(bpy.types.PropertyGroup, MloArchetypeChild):
     def update_room_names(self, context):
         self.room_from_name = self.get_room_name(self.room_from_index)
         self.room_to_name = self.get_room_name(self.room_to_index)
+        del self.__name
 
     def get_name(self):
+        if hasattr(self, "__name") and self.__name is not None:
+            return self.__name
         if not self.room_from_name or not self.room_to_name:
             self.update_room_names(bpy.context)
 
-        return f"{self.get_portal_index() + 1} | {self.room_from_name} to {self.room_to_name}"
+        # EnumProperty can crash blender if the name isn't referenced anywhere See https://docs.blender.org/api/current/bpy.props.html#bpy.props.EnumProperty
+        # Updating is done by update_room_names
+        self.__name = f"{self.get_portal_index() + 1} | {self.room_from_name} to {self.room_to_name}"
+        return self.__name
 
     # Work around to store audio_occlusion as a string property since blender int property cant store 32 bit unsigned integers
     def update_audio_occlusion(self, context):


### PR DESCRIPTION
This seems to work a lot better for more orientations.

It has a misalignment of about 1-5 degrees on average, but most of the times does find close enough to be used for collisions, more often then the old version.

The execution time is around 0.2 seconds to generate the bounding box, which is more then acceptable in my opintion.

I also changed the axis argument to use a value from -1 to 1, this took some time to figure out, but there's zero documentation about this parameter, but looking in the source code this is a simple multiplier over the "angle" for each axis given, so a value from -1 to 1 makes more sense here.

Since this new version also includes a lot of duplicate angles I added a simple set to check if the rotation matrix was already tried, which saves around half the time of the calculation, this might've also done the same for the other version, but since this tries a lot more angles it's needed.


For the get_name in portalproperties, I added caching for that because Blender invokes the items callback anytime the EnumProperty is either accessed or set, and the get_portal_items invokes portal.name, which in turn invokes get_portal_name, which causes exponential growth in export time causing exports with around 70 portals and 700 entities to take around 10+ minutes. Now they take seconds.

