### PR TITLE
feat(ymap): add calculate extents

### DIFF
--- a/tools/ymaphelper.py
+++ b/tools/ymaphelper.py
@@ -1,8 +1,10 @@
 import bpy
 from pathlib import Path
+from mathutils import Vector
 from ..sollumz_properties import SOLLUMZ_UI_NAMES, SollumType
-from ..tools.blenderhelper import find_bsdf_and_material_output
+from ..tools.blenderhelper import find_bsdf_and_material_output, remove_number_suffix
 from ..shared.obj_reader import obj_read_from_file
+from ..tools.meshhelper import get_combined_bound_box, get_sphere_radius
 
 # TODO: This is not a real flag calculation, definitely need to do better
 
@@ -89,3 +91,159 @@ def get_cargen_mesh() -> bpy.types.Mesh:
         mesh = cargen_obj_mesh.as_bpy_mesh(CARGEN_MESH_NAME)
 
     return mesh
+
+class ExtentsData:
+    def __init__(self, lod_dist, bb_min, bb_max, bs_radius, scale):
+        self.lod_dist = lod_dist
+        self.bb_min = bb_min
+        self.bb_max = bb_max
+        self.bs_radius = bs_radius
+        self.scale = scale
+def get_extents_data(obj, entity_extents_data):
+    archetype_name = remove_number_suffix(obj.name)
+
+    if archetype_name in entity_extents_data:
+        return entity_extents_data[archetype_name]
+
+    def create_extents_data_from_archetype(archetype):
+        return ExtentsData(
+            lod_dist=archetype.lod_dist,
+            bb_min=Vector((archetype.bb_min[0], archetype.bb_min[1], archetype.bb_min[2])),
+            bb_max=Vector((archetype.bb_max[0], archetype.bb_max[1], archetype.bb_max[2])),
+            bs_radius=archetype.bs_radius,
+            scale=Vector((1, 1, 1))
+        )
+
+    # Search in all ytyps
+    for ytyp in bpy.context.scene.ytyps:
+        if ytyp.archetypes:
+            for archetype in ytyp.archetypes:
+                if archetype.name == archetype_name:
+                    entity_extents_data[archetype_name] = create_extents_data_from_archetype(archetype)
+                    return entity_extents_data[archetype_name]
+
+    # No ytyp so we calculate bb
+    bbmin, bbmax = get_combined_bound_box(obj, use_world=True)
+    bs_radius = get_sphere_radius(bbmin, bbmax)
+    entity_extents_data[archetype_name] = ExtentsData(lod_dist=60, bb_min=bbmin, bb_max=bbmax, bs_radius=bs_radius, scale=Vector((1, 1, 1)))
+
+    return entity_extents_data[archetype_name]
+
+def generate_ymap_extents(selected_ymap=None):
+    emin = Vector((float('inf'), float('inf'), float('inf')))
+    emax = Vector((float('-inf'), float('-inf'), float('-inf')))
+    smin = Vector((float('inf'), float('inf'), float('inf')))
+    smax = Vector((float('-inf'), float('-inf'), float('-inf')))
+
+    entity_extents_data = {}
+
+    # Clone of CodeWalker's ymap extents calculations
+    for child in selected_ymap.children:
+        if child.sollum_type == SollumType.YMAP_ENTITY_GROUP:
+            for entity_obj in child.children:
+                if entity_obj.sollum_type == SollumType.DRAWABLE or entity_obj.sollum_type == SollumType.FRAGMENT:
+                    position = entity_obj.location
+                    orientation = entity_obj.rotation_euler.to_matrix()
+
+                    extents_data = get_extents_data(entity_obj, entity_extents_data)
+                    lod_dist = (entity_obj.entity_properties.lod_dist
+                                if entity_obj.entity_properties.lod_dist > -1.0
+                                else extents_data.lod_dist)
+
+                    bbmin = extents_data.bb_min * extents_data.scale
+                    bbmax = extents_data.bb_max * extents_data.scale
+
+                    corners = [
+                        orientation @ Vector((bbmin.x, bbmin.y, bbmin.z)),
+                        orientation @ Vector((bbmin.x, bbmin.y, bbmax.z)),
+                        orientation @ Vector((bbmin.x, bbmax.y, bbmin.z)),
+                        orientation @ Vector((bbmin.x, bbmax.y, bbmax.z)),
+                        orientation @ Vector((bbmax.x, bbmin.y, bbmin.z)),
+                        orientation @ Vector((bbmax.x, bbmin.y, bbmax.z)),
+                        orientation @ Vector((bbmax.x, bbmax.y, bbmin.z)),
+                        orientation @ Vector((bbmax.x, bbmax.y, bbmax.z))
+                    ]
+
+                    emin = Vector(min(emin[i], bbmin[i]) for i in range(3))
+                    emax = Vector(max(emax[i], bbmax[i]) for i in range(3))
+
+                    stream_bbmin = bbmin - Vector((lod_dist, lod_dist, lod_dist))
+                    stream_bbmax = bbmax + Vector((lod_dist, lod_dist, lod_dist))
+
+                    stream_corners = [
+                        orientation @ Vector((stream_bbmin.x, stream_bbmin.y, stream_bbmin.z)),
+                        orientation @ Vector((stream_bbmin.x, stream_bbmin.y, stream_bbmax.z)),
+                        orientation @ Vector((stream_bbmin.x, stream_bbmax.y, stream_bbmin.z)),
+                        orientation @ Vector((stream_bbmin.x, stream_bbmax.y, stream_bbmax.z)),
+                        orientation @ Vector((stream_bbmax.x, stream_bbmin.y, stream_bbmin.z)),
+                        orientation @ Vector((stream_bbmax.x, stream_bbmin.y, stream_bbmax.z)),
+                        orientation @ Vector((stream_bbmax.x, stream_bbmax.y, stream_bbmin.z)),
+                        orientation @ Vector((stream_bbmax.x, stream_bbmax.y, stream_bbmax.z))
+                    ]
+
+                    for corner in corners:
+                        corner_world = position + corner
+                        emin = Vector(min(emin[i], corner_world[i]) for i in range(3))
+                        emax = Vector(max(emax[i], corner_world[i]) for i in range(3))
+
+                    for stream_corner in stream_corners:
+                        stream_corner_world = position + stream_corner
+                        smin = Vector(min(smin[i], stream_corner_world[i]) for i in range(3))
+                        smax = Vector(max(smax[i], stream_corner_world[i]) for i in range(3))
+
+        elif child.sollum_type == SollumType.YMAP_BOX_OCCLUDER_GROUP:
+            for box_obj in child.children:
+                if box_obj.sollum_type == SollumType.YMAP_BOX_OCCLUDER:
+                    position = box_obj.location
+                    size = box_obj.dimensions
+
+                    bbmin = position - size
+                    bbmax = position + size
+
+                    emin = Vector(min(emin[i], bbmin[i]) for i in range(3))
+                    emax = Vector(max(emax[i], bbmax[i]) for i in range(3))
+                    smin = Vector(min(smin[i], bbmin[i]) for i in range(3))
+                    smax = Vector(max(smax[i], bbmax[i]) for i in range(3))
+
+        elif child.sollum_type == SollumType.YMAP_MODEL_OCCLUDER_GROUP:
+            for model_obj in child.children:
+                if model_obj.sollum_type == SollumType.YMAP_MODEL_OCCLUDER:
+                    bbmin, bbmax = get_combined_bound_box(model_obj, use_world=True)
+
+                    emin = Vector(min(emin[i], bbmin[i]) for i in range(3))
+                    emax = Vector(max(emax[i], bbmax[i]) for i in range(3))
+                    smin = Vector(min(smin[i], bbmin[i]) for i in range(3))
+                    smax = Vector(max(smax[i], bbmax[i]) for i in range(3))
+
+        elif child.sollum_type == SollumType.YMAP_CAR_GENERATOR_GROUP:
+            for cargen_obj in child.children:
+                if cargen_obj.sollum_type == SollumType.YMAP_CAR_GENERATOR:
+                    position = cargen_obj.location
+                    perpendicular_length = Vector((
+                        cargen_obj.ymap_cargen_properties.perpendicular_length,
+                        cargen_obj.ymap_cargen_properties.perpendicular_length,
+                        cargen_obj.ymap_cargen_properties.perpendicular_length
+                    ))
+
+                    bbmin = position - perpendicular_length
+                    bbmax = position + perpendicular_length
+
+                    emin = Vector(min(emin[i], bbmin[i]) for i in range(3))
+                    emax = Vector(max(emax[i], bbmax[i]) for i in range(3))
+
+                    sbmin = position - perpendicular_length * 2.0
+                    sbmax = position + perpendicular_length * 2.0
+
+                    smin = Vector(min(smin[i], sbmin[i]) for i in range(3))
+                    smax = Vector(max(smax[i], sbmax[i]) for i in range(3))
+
+        # TODO: grass
+
+        # TODO: lod lights
+
+        # TODO: distant lod lights
+
+    selected_ymap.ymap_properties.entities_extents_min = emin
+    selected_ymap.ymap_properties.entities_extents_max = emax
+    selected_ymap.ymap_properties.streaming_extents_min = smin
+    selected_ymap.ymap_properties.streaming_extents_max = smax

--- a/ymap/operators.py
+++ b/ymap/operators.py
@@ -1,6 +1,6 @@
 import bpy
 from ..sollumz_helper import SOLLUMZ_OT_base, set_object_collection
-from ..tools.ymaphelper import add_occluder_material, create_ymap, create_ymap_group, get_cargen_mesh
+from ..tools.ymaphelper import add_occluder_material, create_ymap, create_ymap_group, get_cargen_mesh, generate_ymap_extents
 from ..sollumz_properties import SollumType
 
 
@@ -206,3 +206,12 @@ class SOLLUMZ_OT_create_car_generator(SOLLUMZ_OT_base, bpy.types.Operator):
         context.view_layer.objects.active = cargen_obj
 
         return True
+
+class SOLLUMZ_OT_generate_ymap_extents(bpy.types.Operator):
+    bl_idname = "sollumz.generate_ymap_extents"
+    bl_label = "Generate Ymap Extents"
+    bl_description = "Generate the YMAP's streaming and entity extents (using YMAP and YTYP entities data)"
+
+    def execute(self, context):
+        generate_ymap_extents(selected_ymap=context.active_object)
+        return {"FINISHED"}

--- a/ymap/properties.py
+++ b/ymap/properties.py
@@ -102,10 +102,10 @@ class YmapProperties(bpy.types.PropertyGroup):
     content_flags: IntProperty(name="Content Flags", default=0, min=0, max=(
         2**11)-1, update=ContentFlagPropertyGroup.update_flags_total)
 
-    streaming_extents_min: FloatVectorProperty()
-    streaming_extents_max: FloatVectorProperty()
-    entities_extents_min: FloatVectorProperty()
-    entities_extents_max: FloatVectorProperty()
+    streaming_extents_min: FloatVectorProperty(name="Streaming Extents Min", default=(0, 0, 0), size=3, subtype='XYZ')
+    streaming_extents_max: FloatVectorProperty(name="Streaming Extents Max", default=(0, 0, 0), size=3, subtype='XYZ')
+    entities_extents_min: FloatVectorProperty(name="Entities Extents Min", default=(0, 0, 0), size=3, subtype='XYZ')
+    entities_extents_max: FloatVectorProperty(name="Entities Extents Max", default=(0, 0, 0), size=3, subtype='XYZ')
 
     flags_toggle: PointerProperty(type=MapFlags)
     content_flags_toggle: PointerProperty(type=ContentFlags)

--- a/ymap/ui.py
+++ b/ymap/ui.py
@@ -44,6 +44,16 @@ def draw_ymap_properties(self, context):
         row.prop(obj.ymap_properties.content_flags_toggle,
                  "has_grass", toggle=1)
 
+        layout.label(text="Extents")
+        layout.prop(obj.ymap_properties, "entities_extents_min")
+        layout.prop(obj.ymap_properties, "entities_extents_max")
+        layout.prop(obj.ymap_properties, "streaming_extents_min")
+        layout.prop(obj.ymap_properties, "streaming_extents_max")
+
+        layout.separator()
+        layout.operator("sollumz.generate_ymap_extents", icon="FILE_REFRESH")
+
+
 
 def draw_ymap_model_occluder_properties(self, context):
     obj = context.active_object


### PR DESCRIPTION
This PR introduces extent calculation for ymaps on save and with a button.

I've tested my changes with:
- Custom ymaps
- Vanilla ymaps (drawable entities, occluders, cargens)

If all entities are loaded properly the extents are the same as in CodeWalker.
Did not run any tests though.