### PR TITLE
Fix: Apply Flag Preset When Creating Bound GeometryBVH

### DIFF
--- a/tools/boundhelper.py
+++ b/tools/boundhelper.py
@@ -87,27 +87,24 @@ def create_bound_disc():
     return bound_obj
 
 
-def convert_objs_to_composites(objs: list[bpy.types.Object], bound_child_type: SollumType, apply_default_flags: bool = False):
+def convert_objs_to_composites(objs: list[bpy.types.Object], bound_child_type: SollumType, preset: int = None):
     """Convert each object in ``objs`` to a Bound Composite."""
     for obj in objs:
-        convert_obj_to_composite(obj, bound_child_type, apply_default_flags)
+        convert_obj_to_composite(obj, bound_child_type, preset)
 
 
-def convert_objs_to_single_composite(objs: list[bpy.types.Object], bound_child_type: SollumType, apply_default_flags: bool = False):
+def convert_objs_to_single_composite(objs: list[bpy.types.Object], bound_child_type: SollumType, preset: int = None):
     """Create a single composite from all ``objs``."""
     composite_obj = create_empty_object(SollumType.BOUND_COMPOSITE)
-
     for obj in objs:
         if bound_child_type == SollumType.BOUND_GEOMETRY:
-            convert_obj_to_geometry(obj, apply_default_flags)
+            convert_obj_to_geometry(obj, preset)
             obj.parent = composite_obj
         else:
-            bvh_obj = convert_obj_to_bvh(obj, apply_default_flags)
+            bvh_obj = convert_obj_to_bvh(obj, preset)
             bvh_obj.parent = composite_obj
-
             bvh_obj.location = obj.location
             obj.location = Vector()
-
     return composite_obj
 
 
@@ -152,7 +149,7 @@ def convert_obj_to_geometry(obj: bpy.types.Object, apply_default_flags: bool):
     obj.name = f"{remove_number_suffix(obj.name)}.bound_geom"
 
     if apply_default_flags:
-        apply_default_flag_preset(obj)
+        apply_flag_preset(obj)
 
 
 def convert_obj_to_bvh(obj: bpy.types.Object, apply_default_flags: bool):
@@ -166,12 +163,12 @@ def convert_obj_to_bvh(obj: bpy.types.Object, apply_default_flags: bool):
     obj.parent = bvh_obj
 
     if apply_default_flags:
-        apply_default_flag_preset(bvh_obj)
+        apply_flag_preset(bvh_obj)
 
     return bvh_obj
 
 
-def apply_default_flag_preset(obj: bpy.types.Object):
+def apply_flag_preset(obj: bpy.types.Object):
     load_flag_presets()
 
     preset = flag_presets.presets[0]

--- a/ybn/operators.py
+++ b/ybn/operators.py
@@ -160,6 +160,29 @@ class SOLLUMZ_OT_create_bound(bpy.types.Operator):
             bound_obj = create_empty_object(bound_type)
             bound_obj.parent = parent
 
+            # Check if a flag preset is selected and apply it
+            index = context.window_manager.sz_flag_preset_index
+            load_flag_presets()
+
+            try:
+                preset = flag_presets.presets[index]
+
+                for flag_name in BoundFlags.__annotations__.keys():
+                    if flag_name in preset.flags1:
+                        bound_obj.composite_flags1[flag_name] = True
+                    else:
+                        bound_obj.composite_flags1[flag_name] = False
+
+                    if flag_name in preset.flags2:
+                        bound_obj.composite_flags2[flag_name] = True
+                    else:
+                        bound_obj.composite_flags2[flag_name] = False
+
+                self.report({"INFO"}, f"Applied preset '{preset.name}' to new Bound GeometryBVH object.")
+
+            except IndexError:
+                self.report({"WARNING"}, "Flag preset does not exist or is not selected.")
+
             return {"FINISHED"}
 
         bound_obj = create_bound_shape(bound_type)

--- a/ybn/operators.py
+++ b/ybn/operators.py
@@ -477,6 +477,7 @@ class SOLLUMZ_OT_load_flag_preset(SOLLUMZ_OT_base, bpy.types.Operator):
                     f"Flag preset does not exist! Ensure the preset file is present in the '{filepath}' directory.")
                 return False
 
+        tag_redraw(context)
         return True
 
 

--- a/ybn/properties.py
+++ b/ybn/properties.py
@@ -449,8 +449,6 @@ def register():
     bpy.types.Scene.split_collision_count = bpy.props.IntProperty(
         name="Divide By", description=f"Amount to split {SOLLUMZ_UI_NAMES[SollumType.BOUND_GEOMETRYBVH]}s or {SOLLUMZ_UI_NAMES[SollumType.BOUND_COMPOSITE]}s by", default=2, min=2)
 
-    bpy.types.Scene.composite_apply_default_flag_preset = bpy.props.BoolProperty(
-        name="Apply Default Flag", description=f"Apply the default flag preset to the bound children", default=True)
     bpy.types.Scene.center_composite_to_selection = bpy.props.BoolProperty(
         name="Center to Selection", description="Center the Bound Composite to all selected objects", default=True)
 
@@ -476,7 +474,6 @@ def unregister():
     del bpy.types.Scene.create_bound_type
     del bpy.types.Scene.bound_child_type
     del bpy.types.Scene.split_collision_count
-    del bpy.types.Scene.composite_apply_default_flag_preset
     del bpy.types.Scene.center_composite_to_selection
     del bpy.types.WindowManager.sz_create_bound_box_parent
 

--- a/ybn/ui.py
+++ b/ybn/ui.py
@@ -299,7 +299,6 @@ class SOLLUMZ_PT_CREATE_BOUND_PANEL(CollisionToolChildPanel, bpy.types.Panel):
 
         row = layout.row()
         row.prop(context.scene, "create_seperate_composites")
-        row.prop(context.scene, "composite_apply_default_flag_preset")
         row.prop(context.scene, "center_composite_to_selection")
 
         layout.separator()

--- a/ydr/operators.py
+++ b/ydr/operators.py
@@ -99,7 +99,11 @@ class SOLLUMZ_OT_convert_to_drawable(bpy.types.Operator):
                 drawable_obj = convert_obj_to_drawable(obj)
 
                 if auto_embed_col:
-                    composite_obj = convert_obj_to_composite(duplicate_object(obj), SollumType.BOUND_GEOMETRYBVH, True)
+                    composite_obj = convert_obj_to_composite(
+                        duplicate_object(obj),
+                        SollumType.BOUND_GEOMETRYBVH,
+                        context.window_manager.sz_flag_preset_index
+                    )
                     composite_obj.parent = drawable_obj
                     composite_obj.name = f"{drawable_obj.name}.col"
 
@@ -122,7 +126,11 @@ class SOLLUMZ_OT_convert_to_drawable(bpy.types.Operator):
 
             if auto_embed_col:
                 col_objs = [duplicate_object(o) for o in selected_meshes]
-                composite_obj = convert_objs_to_single_composite(col_objs, SollumType.BOUND_GEOMETRYBVH, True)
+                composite_obj = convert_objs_to_single_composite(
+                    col_objs,
+                    SollumType.BOUND_GEOMETRYBVH,
+                    context.window_manager.sz_flag_preset_index
+                )
                 composite_obj.parent = drawable_obj
 
 


### PR DESCRIPTION
This PR ensures that the selected flag preset is automatically applied when creating a new Bound GeometryBVH object, matching the behavior of converting objects to bounds. Previously, flag presets were not applied during creation.

Fix for: https://github.com/Sollumz/Sollumz/issues/1000