### PR TITLE
fix(ydrexport): Emit warning when duplicate material is found in list

### DIFF
--- a/ydr/ydrexport.py
+++ b/ydr/ydrexport.py
@@ -395,6 +395,8 @@ def get_loop_inds_by_material(mesh: bpy.types.Mesh, drawable_mats: list[bpy.type
 
         loop_indices = all_loop_inds[tri_loop_inds]
 
+        if shader_index in loop_inds_by_mat:
+            logger.warning(f"Shader_index already in list, some geometry will be lost! This is most likely caused by a duplicate material for {mat.name} in {mesh.name}")
         loop_inds_by_mat[shader_index] = loop_indices
 
     return loop_inds_by_mat


### PR DESCRIPTION
This can happen when merging objects together and causes geometry to be overriden, so emit a warning in the case this happens so the user can fix this issue.

Issue speaks for itself, I could've fixed it by merging the arrays, but this seems more like an issue the user can solve in the model so I decided for this course of action.

This is better behavior than silently overwriting the existing geometry and finding holes in the model after importing it into the game (or codewalker)