### PR TITLE
Unhandled Error Fix

### DIFF
--- a/ytyp/operators/extensions.py
+++ b/ytyp/operators/extensions.py
@@ -123,7 +123,8 @@ class ExtensionUpdateFromSelectionHelper:
 
     @classmethod
     def poll(cls, context):
-        return get_selected_extension(context) is not None
+        aobj = context.active_object
+        return get_selected_extension(context) is not None and aobj and aobj.mode == "EDIT"
 
     @classmethod
     def set_extension_props(cls, context: bpy.types.Context, verts_location: Vector):


### PR DESCRIPTION
Trying to get the vertices in Object mode could lead to unhandled errors like:

AttributeError: 'NoneType' object has no attribute 'update_from_editmode'.
ZeroDivisionError: Vector division: divide by zero error.

Let's just make sure we are in edit mode when interacting with vertices.