### PR TITLE
feat(ui): allow non-sollumz material conversion from material properties

### DIFF
--- a/sollumz_pie.py
+++ b/sollumz_pie.py
@@ -17,7 +17,7 @@ class SOLLUMZ_MT_pie_menu(Menu):
 
         pie = layout.menu_pie()
         # Left
-        pie.operator("sollumz.autoconvertmaterial",
+        pie.operator("sollumz.autoconvertmaterials",
                      text="Convert Material", icon='NODE_MATERIAL')
         # Right
         pie.operator("sollumz.addobjasentity", icon='OBJECT_DATA')

--- a/sollumz_ui.py
+++ b/sollumz_ui.py
@@ -1,9 +1,10 @@
 import bpy
 from bl_ui.space_statusbar import STATUSBAR_HT_header
 from typing import Optional
+
+from .ydr.operators import SOLLUMZ_OT_convert_active_material_to_selected, SOLLUMZ_OT_auto_convert_current_material
 from .sollumz_preferences import get_addon_preferences, get_export_settings, get_import_settings, SollumzImportSettings, SollumzExportSettings
 from .sollumz_operators import SOLLUMZ_OT_copy_location, SOLLUMZ_OT_copy_rotation, SOLLUMZ_OT_paste_location, SOLLUMZ_OT_paste_rotation
-from .tools.blenderhelper import get_armature_obj
 from .sollumz_properties import (
     SollumType,
     MaterialType,
@@ -584,7 +585,23 @@ class SOLLUMZ_PT_MAT_PANEL(bpy.types.Panel):
         mat = aobj.active_material
 
         if not mat or mat.sollum_type == MaterialType.NONE:
-            layout.label(text="No sollumz material active.", icon="ERROR")
+            layout.label(text="Material is not a Sollumz material.", icon="ERROR")
+
+            box = layout.box()
+
+            from .ydr.ui import SOLLUMZ_UL_SHADER_MATERIALS_LIST
+
+            wm = context.window_manager
+
+            box.template_list(
+                SOLLUMZ_UL_SHADER_MATERIALS_LIST.bl_idname, "",
+                wm, "sz_shader_materials", wm, "sz_shader_material_index",
+            )
+
+            row = box.row()
+            row.operator(SOLLUMZ_OT_convert_active_material_to_selected.bl_idname, text="Convert to Selected", icon="FILE_REFRESH")
+            row.operator(SOLLUMZ_OT_auto_convert_current_material.bl_idname, text="Auto Convert", icon="FILE_REFRESH")
+
             return
 
 

--- a/tools/drawablehelper.py
+++ b/tools/drawablehelper.py
@@ -100,10 +100,7 @@ class MaterialConverter:
 
         self.diffuse_node = self._get_diffuse_node()
 
-        if self.diffuse_node is None:
-            raise Exception("Failed to convert material: Material must have an image node linked to the base color.")
-
-        if not isinstance(self.diffuse_node, bpy.types.ShaderNodeTexImage):
+        if self.diffuse_node is not None and not isinstance(self.diffuse_node, bpy.types.ShaderNodeTexImage):
             raise Exception("Failed to convert material: Base color node is not an image node.")
 
         self.specular_node = self._get_specular_node()

--- a/ydr/ui.py
+++ b/ydr/ui.py
@@ -437,7 +437,7 @@ class SOLLUMZ_PT_SHADER_TOOLS_PANEL(bpy.types.Panel):
 
         row = layout.row()
         row.operator(
-            ydr_ops.SOLLUMZ_OT_auto_convert_material.bl_idname, text="Auto Convert", icon="FILE_REFRESH")
+            ydr_ops.SOLLUMZ_OT_auto_convert_materials.bl_idname, text="Auto Convert", icon="FILE_REFRESH")
         grid = layout.grid_flow(align=True)
         grid.operator(
             ydr_ops.SOLLUMZ_OT_set_all_textures_embedded.bl_idname, icon="TEXTURE")


### PR DESCRIPTION
feat(ui): allow non-sollumz material conversion from material properties

It is a pain to go in shader option everytime you create/convert a material, so here is how the Sollumz material properties looks now:
<img width="1785" height="841" alt="Sollumz_Material_PR" src="https://github.com/user-attachments/assets/119f2108-55b6-400d-ad04-bbcb98156aef" />

Introduced two new operators for converting materials: `SOLLUMZ_OT_convert_active_material_to_selected` and `SOLLUMZ_OT_auto_convert_current_material`, who will only affect active material of the active object.
For better clarity I also renamed `SOLLUMZ_OT_auto_convert_material` to `SOLLUMZ_OT_auto_convert_materials` and tweaked his description since the operator affect all selected objects.

This commit also allow converting a material with no diffuse node image texture, which was really annoying.
