### PR TITLE
feat(materials): convert existing drawable material instead of replacing it

### DIFF
--- a/tests/test_shader_creation.py
+++ b/tests/test_shader_creation.py
@@ -70,8 +70,9 @@ def test_convert_shader_to_shader(src_shader, dst_shader, plane_object):
     plane_object.data.materials.append(src_mat)
     mat = MaterialConverter(plane_object, src_mat).convert(dst_shader)
     assert mat is not None
-    assert src_mat != mat
+    assert src_mat == mat
     assert plane_object.data.materials[0] == mat
+    assert mat.shader_properties.filename == dst_shader
 
 
 def test_ops_update_tint_shader_correctly_syncs_attribute_names(plane_object):

--- a/ydr/operators.py
+++ b/ydr/operators.py
@@ -770,43 +770,6 @@ class SOLLUMZ_OT_create_shader_material(SOLLUMZ_OT_base, bpy.types.Operator):
         return True
 
 
-class SOLLUMZ_OT_change_shader(SOLLUMZ_OT_base, bpy.types.Operator):
-    """Change the shader used by the active material"""
-    bl_idname = "sollumz.change_shader"
-    bl_label = "Change Shader"
-    bl_action = "Change Shader of Material"
-
-    shader_index: IntProperty(name="Shader Index", min=0, max=len(shadermats) - 1)
-
-    @classmethod
-    def poll(cls, context):
-        aobj = context.active_object
-        return (
-            aobj and
-            aobj.type == "MESH" and
-            aobj.active_material and
-            aobj.active_material.sollum_type == MaterialType.SHADER
-        )
-
-    def run(self, context):
-        aobj = context.active_object
-        mat = aobj.active_material
-        old_shader_filename = mat.shader_properties.filename
-        new_shader_filename = shadermats[self.shader_index].value
-
-        tmp_preset = shader_preset_from_material(mat)
-        create_shader(new_shader_filename, in_place_material=mat)
-        shader_preset_apply_to_material(mat, tmp_preset, apply_textures=True)
-
-        post_create_shader_add_default_images(mat)
-        for obj in bpy.data.objects:  # update all objects that are using this material
-            if obj.type == "MESH" and mat.name in obj.data.materials:
-                post_create_shader_update_object(obj, mat)
-
-        self.message(f"Changed {old_shader_filename} shader to {new_shader_filename}.")
-        return True
-
-
 class SOLLUMZ_OT_set_all_textures_embedded(SOLLUMZ_OT_base, bpy.types.Operator):
     """Sets all textures to embedded on the selected objects active material"""
     bl_idname = "sollumz.setallembedded"

--- a/ydr/shader_materials.py
+++ b/ydr/shader_materials.py
@@ -1,5 +1,7 @@
 from typing import Optional, NamedTuple
 import bpy
+
+
 from ..cwxml.shader import (
     ShaderManager,
     ShaderDef,
@@ -12,8 +14,8 @@ from ..cwxml.shader import (
     ShaderParameterFloat4x4Def,
 )
 from ..sollumz_properties import MaterialType, MIN_VEHICLE_LIGHT_ID, MAX_VEHICLE_LIGHT_ID
-from ..tools.blenderhelper import find_bsdf_and_material_output
 from ..tools.animationhelper import add_global_anim_uv_nodes
+from ..tools.blenderhelper import find_bsdf_and_material_output
 from ..tools.meshhelper import get_uv_map_name, get_color_attr_name
 from ..shared.shader_nodes import SzShaderNodeParameter, SzShaderNodeParameterDisplayType
 from ..shared.shader_expr import expr, compile_expr
@@ -1260,16 +1262,6 @@ def create_shader(filename: str, in_place_material: Optional[bpy.types.Material]
         material_ouput = current_node_tree.nodes.new("ShaderNodeOutputMaterial")
         bsdf = current_node_tree.nodes.new("ShaderNodeBsdfPrincipled")
         current_node_tree.links.new(bsdf.outputs["BSDF"], material_ouput.inputs["Surface"])
-
-        # If the material had a default name based on its current shader, replace it with the new shader name
-        import re
-        current_filename = in_place_material.shader_properties.filename
-        if (
-            in_place_material.sollum_type == MaterialType.SHADER and
-            current_filename and
-            re.match(rf"{current_filename.replace('.sps', '')}(\.\d\d\d)?", in_place_material.name)
-        ):
-            in_place_material.name = material_name
 
     mat = in_place_material or bpy.data.materials.new(material_name)
     mat.sollum_type = MaterialType.SHADER

--- a/ydr/ui.py
+++ b/ydr/ui.py
@@ -754,7 +754,7 @@ class SOLLUMZ_PT_change_shader(bpy.types.Panel):
             SOLLUMZ_UL_SHADER_MATERIALS_LIST.bl_idname, "",
             wm, "sz_shader_materials", wm, "sz_shader_material_index"
         )
-        op = layout.operator(ydr_ops.SOLLUMZ_OT_change_shader.bl_idname)
+        op = layout.operator(ydr_ops.SOLLUMZ_OT_convert_active_material_to_selected.bl_idname, text="Convert")
         op.shader_index = wm.sz_shader_material_index
 
 


### PR DESCRIPTION
Avoid duplicated materials when converting to Sollumz shader.

Previously, converting a material created a new one per selected object using it, causing duplicates.
Now, we rely on users to duplicate materials manually if needed — standard Blender workflow.

Removed `SOLLUMZ_OT_change_shader`, since `SOLLUMZ_OT_convert_active_material_to_selected` does the job now.

Also dropped the shader name suffix in material names. If re-added later, it should be cleaner and use a better separator like " | ".

EDIT: One question remains: should we apply the same logic to collision material conversion, or just rename the related operators from "Convert to selected" to "Replace with selected" to make their behavior clearer to users?