### PR TITLE
tweak(ybn): minor fixes for bound flags and export

### DIFF
--- a/ybn/properties.py
+++ b/ybn/properties.py
@@ -28,7 +28,11 @@ class CollisionMatFlags(bpy.types.PropertyGroup):
     no_decal: bpy.props.BoolProperty(name="NO DECAL", default=False)
     no_navmesh: bpy.props.BoolProperty(name="NO NAVMESH", default=False)
     no_ragdoll: bpy.props.BoolProperty(name="NO RAGDOLL", default=False)
-    vehicle_wheel: bpy.props.BoolProperty(name="VEHICLE WHEEL", default=False)
+    vehicle_wheel: bpy.props.BoolProperty(
+        name="VEHICLE WHEEL",
+        description="Runtime-only flag, cleared on export. The game sets it itself during shape tests and asserts "
+                    "that it is not present in resources",
+        default=False)
     no_ptfx: bpy.props.BoolProperty(name="NO PTFX", default=False)
     too_steep_for_player: bpy.props.BoolProperty(name="TOO STEEP FOR PLAYER", default=False)
     no_network_spawn: bpy.props.BoolProperty(name="NO NETWORK SPAWN", default=False)
@@ -174,8 +178,8 @@ _collision_material_mlo_archetype_cache = {}  # [material name] -> (ytyp index, 
 class CollisionProperties(CollisionMatFlags, bpy.types.PropertyGroup):
     collision_index: bpy.props.IntProperty(name="Collision Index", default=0)
     procedural_id: bpy.props.IntProperty(name="Procedural ID", default=0, min=0, max=MAX_NUM_PROCEDURAL_IDS-1)
-    room_id: bpy.props.IntProperty(name="Room ID", default=0, min=0)
-    ped_density: bpy.props.IntProperty(name="Ped Density", default=0)
+    room_id: bpy.props.IntProperty(name="Room ID", default=0, min=0, max=31)
+    ped_density: bpy.props.IntProperty(name="Ped Density", default=0, min=0, max=7)
     material_color_index: bpy.props.IntProperty(name="Material Color Index", default=0)
 
     def _get_procedural_id(self) -> int:
@@ -250,6 +254,7 @@ class BoundFlags(bpy.types.PropertyGroup):
     map_vehicle: bpy.props.BoolProperty(name="MAP VEHICLE", default=False)
     vehicle_not_bvh: bpy.props.BoolProperty(name="VEHICLE NOT BVH", default=False)
     vehicle_bvh: bpy.props.BoolProperty(name="VEHICLE BVH", default=False)
+    vehicle_box: bpy.props.BoolProperty(name="VEHICLE BOX", default=False)
     ped: bpy.props.BoolProperty(name="PED", default=False)
     ragdoll: bpy.props.BoolProperty(name="RAGDOLL", default=False)
     animal: bpy.props.BoolProperty(name="ANIMAL", default=False)

--- a/ybn/ybnexport.py
+++ b/ybn/ybnexport.py
@@ -820,6 +820,12 @@ def create_collision_material_data(mat: Material) -> CollisionMaterial:
 
     col_props = mat.collision_properties
     flags_lo, flags_hi = get_collision_mat_raw_flags(mat.collision_flags)
+    if flags_hi & (1 << 3):
+        flags_hi &= ~(1 << 3)
+        logger.warning(
+            f"Collision material '{mat.name}' has the runtime-only VEHICLE WHEEL flag set. "
+            "It has been cleared on export, as the game requires."
+        )
     return CollisionMaterial(
         material_index=col_props.collision_index,
         material_color_index=col_props.material_color_index,


### PR DESCRIPTION
- prevent users from enabling vehicle_wheel flag, supposed to be runtime only
- set max value for room IDs and ped densities
- add missing vehicle_box bound flag